### PR TITLE
Add CMake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,4 +16,8 @@ target_include_directories(cxxcurses INTERFACE include)
 target_link_libraries(cxxcurses INTERFACE Curses::ncurses)
 target_compile_features(cxxcurses INTERFACE cxx_std_17)
 
+if (NOT CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    return()
+endif()
+
 add_subdirectory(sample)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.16)
+project(cxxcurses CXX)
+
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(CURSES_NEED_NCURSES TRUE)
+find_package(Curses REQUIRED)
+add_library(Curses::ncurses INTERFACE IMPORTED)
+target_include_directories(Curses::ncurses SYSTEM INTERFACE ${CURSES_INCLUDE_DIRS})
+target_link_libraries(Curses::ncurses INTERFACE ${CURSES_LIBRARIES})
+
+add_library(cxxcurses INTERFACE)
+add_library(cxxcurses::cxxcurses ALIAS cxxcurses)
+target_include_directories(cxxcurses INTERFACE include)
+target_link_libraries(cxxcurses INTERFACE Curses::ncurses)
+target_compile_features(cxxcurses INTERFACE cxx_std_17)
+
+add_subdirectory(sample)

--- a/include/cxxcurses/print.hpp
+++ b/include/cxxcurses/print.hpp
@@ -30,7 +30,7 @@ struct printer
 
     using coords_t = std::pair<std::optional<int>, std::optional<int>>;
     const coords_t coords {};
-    glyph_string format_str;
+    glyph_string format_str {};
 };
 
 // move and print

--- a/include/cxxcurses/print/glyph_string.hpp
+++ b/include/cxxcurses/print/glyph_string.hpp
@@ -27,7 +27,7 @@ public:
     glyph_string( const glyph_string& ) = default;
     glyph_string( glyph_string&& ) = default;
     auto operator=( const glyph_string& ) -> glyph_string& = default;
-    auto operator=( glyph_string && ) -> glyph_string& = default;
+    auto operator=( glyph_string&& ) -> glyph_string& = default;
     ~glyph_string() = default;
 
     explicit glyph_string( const std::string_view& string,
@@ -48,7 +48,7 @@ public:
     }
 };
 
-auto parse_arg( std::string_view /*to_parse*/, glyph_string & /*parsed*/ )
+auto parse_arg( std::string_view /*to_parse*/, glyph_string& /*parsed*/ )
     -> glyph_string
 {
     return {};

--- a/include/cxxcurses/terminal/terminal.hpp
+++ b/include/cxxcurses/terminal/terminal.hpp
@@ -10,8 +10,8 @@
 #ifndef CXXCURSES_TERMINAL_INITIALIZER_HPP
 #define CXXCURSES_TERMINAL_INITIALIZER_HPP
 
-#include "../print.hpp"
-#include "../widgets.hpp"
+#include <cxxcurses/print.hpp>
+#include <cxxcurses/widgets.hpp>
 
 #include <curses.h>
 

--- a/include/cxxcurses/terminal/terminal.hpp
+++ b/include/cxxcurses/terminal/terminal.hpp
@@ -39,7 +39,7 @@ struct terminal
     terminal( const terminal& ) = delete;
     terminal( terminal&& ) = delete;
     auto operator=( const terminal& ) -> terminal& = delete;
-    auto operator=( terminal && ) -> terminal& = delete;
+    auto operator=( terminal&& ) -> terminal& = delete;
 
     ~terminal()
     {

--- a/include/cxxcurses/widget/widget.hpp
+++ b/include/cxxcurses/widget/widget.hpp
@@ -26,7 +26,7 @@ public:
     widget_interface() = default;
     widget_interface( const widget_interface& ) = delete;
     widget_interface( widget_interface&& ) = default;
-    auto operator=( widget_interface && ) -> widget_interface& = default;
+    auto operator=( widget_interface&& ) -> widget_interface& = default;
     auto operator=( const widget_interface& ) -> widget_interface& = delete;
 };
 

--- a/include/cxxcurses/widget/window.hpp
+++ b/include/cxxcurses/widget/window.hpp
@@ -99,7 +99,7 @@ public:
     window( const window& ) = delete;
     window( window&& ) = delete;
     auto operator=( const window& ) -> window& = delete;
-    auto operator=( window && ) -> window& = delete;
+    auto operator=( window&& ) -> window& = delete;
     ~window() override = default;
 
     void draw() const override

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -1,17 +1,2 @@
-cmake_minimum_required(VERSION 3.14)
-project(cxxcurses_sample)
-
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}/bin")
-set(CMAKE_CXX_STANDARD 17)
-set(CURSES_NEED_NCURSES TRUE)
-
-find_package(Curses REQUIRED)
-
-include_directories(SYSTEM "${CURSES_INCLUDE_DIR}")
-include_directories("../include")
-link_directories("${CURSES_INCLUDE_DIRS}")
-
-set(SOURCE_FILES main.cpp)
-
-add_executable(${PROJECT_NAME} ${SOURCE_FILES})
-target_link_libraries(${PROJECT_NAME} ${CURSES_LIBRARIES})
+add_executable(cxxcurses_sample main.cpp)
+target_link_libraries(cxxcurses_sample cxxcurses::cxxcurses)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,2 +1,0 @@
- 
-# test cmake


### PR DESCRIPTION
@hjaremko, I wanted to try this out with a project of mine that uses ncurses a lot so I went ahead and added CMake to the whole project so people can easily ingest and use what you've made. The idea is that the `cxxcurses::cxxcurses` target includes every requirement for using it so that users can simply write `target_link_libraries(my-target cxxcurses::cxxcurses)` and get the whole library.