### PR TITLE
Inline free functions to avoid redefinition errors when linking

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,10 @@
----
-Checks:          '*,-fuchsia-*,-google-*,-zircon-*,-abseil-*,-llvm-*'
-WarningsAsErrors: '1'
-HeaderFilterRegex: ''
-FormatStyle:     none
-
-
+Checks: 'clang-analyzer-*,bugprone-*,performance-*,misc-*,modernize-*,readability-identifier-naming'
+CheckOptions:
+  - { key: readability-identifier-naming.ClassCase,           value: lower_case }
+  - { key: readability-identifier-naming.FunctionCase,        value: lower_case }
+  - { key: readability-identifier-naming.VariableCase,        value: lower_case }
+  - { key: readability-identifier-naming.MemberCase,          value: lower_case }
+  - { key: readability-identifier-naming.PrivateMemberCase,   value: lower_case }
+  - { key: readability-identifier-naming.PrivateMemberSuffix, value: _ }
+WarningsAsErrors: '*'
+HeaderFilterRegex: '*'

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Header-only C++ wrapper aiming to provide more friendly interface
 to the most used (at least by me) functions of ncurses instead of not so fun to use C interface.
 
 ```cpp
-#include "cxxcurses/cxxcurses.hpp"
+#include <cxxcurses/cxxcurses.hpp>
 
 #include <ostream>
 #include <string>
@@ -16,14 +16,15 @@ to the most used (at least by me) functions of ncurses instead of not so fun to 
 class custom_type
 {
 public:
-    friend auto operator<<( std::ostream& os, const custom_type& type ) -> std::ostream&
+    friend auto operator<<( std::ostream& os, const custom_type& type )
+        -> std::ostream&
     {
-        return os << "str: " << type.str << " pi: " << type.pi;
+        return os << "str: " << type.str_ << " pi: " << type.pi_;
     }
 
 private:
-    const std::string str { "user defined" };
-    const double pi { 3.14 };
+    const std::string str_ { "user defined" };
+    const double pi_ { 3.14 };
 };
 
 auto main() -> int
@@ -35,18 +36,18 @@ auto main() -> int
     const auto hello_string { std::string { "Hello, world" } };
 
     main_win << cc::format( 4 )( "C++ curses centered example" );
-    main_win << cc::format( 5, 6 )( "Here comes {rR} {gB} {bB}!!!", "multi", "colored", hello_string );
+    main_win << cc::format( 5, 6 )(
+        "Here comes {rR} {gB} {bB}!!!", "multi", "colored", hello_string );
     main_win << cc::format( 6, 6 )( "Supports {R} types!", custom_type {} );
 
-    auto some_window { cc::widget::window { { 10, 5, 5, 30 }, cc::terminal::main_win } };
+    auto some_window { cc::widget::window { { 10, 5, 5, 30 },
+                                            cc::terminal::main_win } };
 
     some_window << cc::format( 2, 2 )( "Hello from sub-window!" );
     some_window.get_char();
 
     return 0;
 }
-
-
 ```
 
 

--- a/include/cxxcurses/print.hpp
+++ b/include/cxxcurses/print.hpp
@@ -34,26 +34,27 @@ struct printer
 };
 
 // move and print
-auto format( const int y, const int x ) -> printer
+inline auto format( const int y, const int x ) -> printer
 {
     return { std::make_pair( y, x ) };
 }
 
 // centered
-auto format( const int y ) -> printer
+inline auto format( const int y ) -> printer
 {
     return { std::make_pair( y, std::nullopt ) };
 }
 
 template <typename... Args>
-auto format( std::string_view str, Args&&... args ) -> printer
+inline auto format( std::string_view str, Args&&... args ) -> printer
 {
     auto format_str { glyph_string {} };
     parse( str, format_str, ( std::forward<Args>( args ) )... );
     return printer { std::make_pair( std::nullopt, std::nullopt ), format_str };
 }
 
-auto operator<<( const widget::window_interface& w, const printer& formatted )
+inline auto operator<<( const widget::window_interface& w,
+                        const printer& formatted )
     -> const widget::window_interface&
 {
     const auto x =

--- a/include/cxxcurses/print/color.hpp
+++ b/include/cxxcurses/print/color.hpp
@@ -17,6 +17,7 @@ namespace cxxcurses
 {
 enum class color : short
 {
+    none = -1,
     red = COLOR_RED,
     green = COLOR_GREEN,
     yellow = COLOR_YELLOW,

--- a/include/cxxcurses/print/color_pair.hpp
+++ b/include/cxxcurses/print/color_pair.hpp
@@ -23,7 +23,7 @@ struct color_pair
 {
     using type = std::pair<color, color>;
 
-    color_pair( color fg = color::white, color bg = color::black )
+    color_pair( color fg = color::white, color bg = color::none )
     {
         auto pair { type { fg, bg } };
 

--- a/include/cxxcurses/print/glyph_string.hpp
+++ b/include/cxxcurses/print/glyph_string.hpp
@@ -48,17 +48,17 @@ public:
     }
 };
 
-auto parse_arg( std::string_view /*to_parse*/, glyph_string& /*parsed*/ )
+inline auto parse_arg( std::string_view /*to_parse*/, glyph_string& /*parsed*/ )
     -> glyph_string
 {
     return {};
 }
 
 template <typename T, typename... Args>
-auto parse_arg( std::string_view to_parse,
-                glyph_string& parsed,
-                const T& arg,
-                Args&&... args ) -> glyph_string
+inline auto parse_arg( std::string_view to_parse,
+                       glyph_string& parsed,
+                       const T& arg,
+                       Args&&... args ) -> glyph_string
 {
     auto colors { color_pair { color::white } };
     auto attributes { std::vector<attribute> {} };
@@ -94,8 +94,9 @@ auto parse_arg( std::string_view to_parse,
 }
 
 template <typename... Args>
-auto parse( std::string_view to_parse, glyph_string& parsed, Args&&... args )
-    -> glyph_string
+inline auto parse( std::string_view to_parse,
+                   glyph_string& parsed,
+                   Args&&... args ) -> glyph_string
 {
     size_t position = 0;
     for ( auto ch : to_parse )

--- a/include/cxxcurses/terminal/terminal.hpp
+++ b/include/cxxcurses/terminal/terminal.hpp
@@ -22,6 +22,7 @@ struct terminal
     terminal()
     {
         ::initscr();
+        ::keypad( stdscr, TRUE );
         set_echo( false );
         cursor::set_visibility( cursor::visibility::invisible );
 

--- a/include/cxxcurses/terminal/terminal.hpp
+++ b/include/cxxcurses/terminal/terminal.hpp
@@ -33,6 +33,7 @@ struct terminal
         else
         {
             ::start_color();
+            ::use_default_colors();
             init_color_pairs();
         }
     }
@@ -54,13 +55,13 @@ struct terminal
 private:
     static void init_color_pairs() noexcept
     {
-        color_pair( color::red, color::black );
-        color_pair( color::green, color::black );
-        color_pair( color::yellow, color::black );
-        color_pair( color::blue, color::black );
-        color_pair( color::magenta, color::black );
-        color_pair( color::cyan, color::black );
-        color_pair( color::white, color::black );
+        color_pair( color::red, color::none );
+        color_pair( color::green, color::none );
+        color_pair( color::yellow, color::none );
+        color_pair( color::blue, color::none );
+        color_pair( color::magenta, color::none );
+        color_pair( color::cyan, color::none );
+        color_pair( color::white, color::none );
     }
 };
 } // namespace cxxcurses

--- a/sample/main.cpp
+++ b/sample/main.cpp
@@ -1,4 +1,4 @@
-#include "cxxcurses/cxxcurses.hpp"
+#include <cxxcurses/cxxcurses.hpp>
 
 #include <ostream>
 #include <string>
@@ -9,12 +9,12 @@ public:
     friend auto operator<<( std::ostream& os, const custom_type& type )
         -> std::ostream&
     {
-        return os << "str: " << type.str << " pi: " << type.pi;
+        return os << "str: " << type.str_ << " pi: " << type.pi_;
     }
 
 private:
-    const std::string str { "user defined" };
-    const double pi { 3.14 };
+    const std::string str_ { "user defined" };
+    const double pi_ { 3.14 };
 };
 
 auto main() -> int


### PR DESCRIPTION
I was getting "duplicate symbol" errors because multiple .cpp files in the same translation unit were defining the same symbosl and they were clashing. As far as I'm aware, inlining those functions is the best way to ensure those collisions don't cause errors.

Maybe let's move more of the implementation details to .cpp files so that these considerations don't have to be made and to save on compile time for projects that heavily use this library. Header-only makes installation easier but if you're using FetchContent like I am, it makes no different how the `cxxcurses::cxxcurses` target is built.